### PR TITLE
Force http on external domain

### DIFF
--- a/archived-websites.js
+++ b/archived-websites.js
@@ -15,7 +15,11 @@ require(["epfl-jquery"], function($){
           var ul = document.getElementById("list-archived-websites");
           var li = document.createElement("li");
           var a = document.createElement("a");
-          a.href = ("//" + value);
+          if (value.indexOf('epfl.ch') >= 0) {
+            a.href = ("//" + value);
+          } else {
+            a.href = ("http://" + value);
+          }
           a.innerHTML = (value);
           li.appendChild(a);
           ul.appendChild(li);


### PR DESCRIPTION
Example:

http://www.elemo.ch -> https://archiveweb.epfl.ch/www.elemo.ch/
vs
https://www.elemo.ch -> NET::ERR_CERT_COMMON_NAME_INVALID