### PR TITLE
Ignore folders fonts and cdn-cgi

### DIFF
--- a/fill-archivedwebsites-json.py
+++ b/fill-archivedwebsites-json.py
@@ -11,11 +11,9 @@ print 'Run fill-archivedwebsites-json.py...'
 
 directories = listdirs('/var/www/vhosts/archiveweb.epfl.ch/htdocs/')
 
-if 'common' in directories:
-    directories.remove('common')
+directories_to_remove = [ 'common', 'templates', 'fonts', 'cdn-cgi' ]
 
-if 'templates' in directories:
-    directories.remove('templates')
+directories[:] = [item for item in directories if item not in directories_to_remove]
 
 websites_list = json.dumps(directories)
 

--- a/fill-archivedwebsites-json.py
+++ b/fill-archivedwebsites-json.py
@@ -11,7 +11,7 @@ print 'Run fill-archivedwebsites-json.py...'
 
 directories = listdirs('/var/www/vhosts/archiveweb.epfl.ch/htdocs/')
 
-directories_to_remove = [ 'common', 'templates', 'fonts', 'cdn-cgi' ]
+directories_to_remove = ['common', 'templates', 'fonts', 'cdn-cgi']
 
 directories[:] = [item for item in directories if item not in directories_to_remove]
 


### PR DESCRIPTION
Remove folders 'fonts' and 'cdn-cgi' from the list of archived website.

'fonts' comes from Elements and 'cdn-cgi' from Cloudflare.

Close: #19